### PR TITLE
🌱 #182 - Adiciona seed Banner treinamento Elmo

### DIFF
--- a/database/seeders/AdcBannerElmoSeeder.php
+++ b/database/seeders/AdcBannerElmoSeeder.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Seeders;
+
+use Carbon\Carbon;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class AdcBannerElmoSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::table('banner_config')->insert([
+            [
+                'id' => 12,
+                'ordem' => 10,
+                'ativo' => true,
+                'titulo' => 'Treinamentos Elmo',
+                'imagem' => 'https://coronavirus.ceara.gov.br/wp-content/uploads/2021/12/Elmo-Banner-2.jpg',
+                'valor' => 'https://sus.ce.gov.br/elmo/faca-seu-treinamento/',
+                'tipo' => 'webview',
+                'options' => json_encode(
+                    [
+                        'localImagem' => 'web',
+                        'labelAnalytics' => 'banner_treinamento_elmo'
+                    ]
+                ),
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
Co-authored-by: Laysacunha <laysacunha@gmail.com>

Responsáveis:  
@Laysacunha @JefersonNSoares 

Linked Issue:  
Close #182 

### Descrição
Cria seed para adicionar banner de treinamento do ELMO

### Passos a passo para teste

Roda o seed na api local dentro do cli do container api-isus-fpm usando o comando: 
`php artisan db:seed --class=AdcBannerElmoSeeder` 

Sobe o app apontando para API local e verifica o banner adicionado em última opção.

## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [X] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [X] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
