### PR TITLE
Release/i205 relatorio geral

### DIFF
--- a/phpdocker/php-fpm/Dockerfile
+++ b/phpdocker/php-fpm/Dockerfile
@@ -5,9 +5,14 @@ WORKDIR "/application"
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install selected extensions and other stuff
-RUN apt-get update \
-    && apt-get -y --no-install-recommends install php7.4-mysql cron locales \
-    && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+RUN apt-get update; \
+    apt-get -y --no-install-recommends install \
+        php7.4-gd \
+        php7.4-mysql \
+        cron \
+        locales; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 
 # Set the locale timezone to America/Fortaleza
 RUN touch /etc/locale.gen

--- a/phpdocker/php-fpm/Dockerfile
+++ b/phpdocker/php-fpm/Dockerfile
@@ -5,13 +5,13 @@ WORKDIR "/application"
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install selected extensions and other stuff
-RUN apt-get update; \
-    apt-get -y --no-install-recommends install \
+RUN apt-get update \
+    && apt-get -y --no-install-recommends install \
         php7.4-gd \
         php7.4-mysql \
         cron \
-        locales; \
-    apt-get clean; \
+        locales \
+    && apt-get clean; \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 
 # Set the locale timezone to America/Fortaleza


### PR DESCRIPTION
Responsáveis:  
@fpontef 

Linked Issue:  
Close #205 

### Descrição

PR adicional para instalar a extensão do PHP "GD" e satisfazer as dependências do maatwebsite/excel, usado para gerar o relatório em formato XLSX.

### Observações

Caso o ```docker compose up``` não baixe os requisitos da build, informar ```docker compose up --build```

## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
