### PR TITLE
🌱 update bannerseed add diversidade disable manejo clinico

### DIFF
--- a/database/seeders/AdcDefaultBannersSeeder.php
+++ b/database/seeders/AdcDefaultBannersSeeder.php
@@ -140,7 +140,7 @@ class AdcDefaultBannersSeeder extends Seeder
             [
                 'id' => 8,
                 'ordem' => 5,
-                'ativo' => true,
+                'ativo' => false,
                 'titulo' => 'Manejo Clínico',
                 'imagem' => 'https://coronavirus.ceara.gov.br/wp-content/uploads/2022/01/unnamed.png',
                 'valor' => 'https://coronavirus.ceara.gov.br/profissional/manejoclinico/',
@@ -336,6 +336,23 @@ class AdcDefaultBannersSeeder extends Seeder
                     [
                         'localImagem' => 'web',
                         'labelAnalytics' => 'banner_sindrome_gripal_recem-nascido'
+                    ]
+                ),
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
+            [
+                'id' => 20,
+                'ordem' => 5,
+                'ativo' => true,
+                'titulo' => 'Guia de Diversidade',
+                'imagem' => 'https://coronavirus.ceara.gov.br/wp-content/uploads/2022/05/Manual-de-Diversidade.png',
+                'valor' => 'https://coronavirus.ceara.gov.br/project/guia-de-diversidade-igualdade-no-servico-publico-de-saude-do-ceara/',
+                'tipo' => 'webview',
+                'options' => json_encode(
+                    [
+                        'localImagem' => 'web',
+                        'labelAnalytics' => 'banner_guia_diversidade'
                     ]
                 ),
                 'created_at' => Carbon::now(),


### PR DESCRIPTION
Responsáveis:  
@fpontef 

Linked Issue:  
Close #744 - [i744@isus-app](https://github.com/EscolaDeSaudePublica/isus-app/issues/744)

### Descrição

Foi solicitado a inserção do banner do Guia de diversidade na ordem 6.
Solicitação realizada no grupo do iSUS do telegram (feita pela Ariane Cajazeiras).
Solicitou que ele substituísse o banner do manejo covid.

### Passos a passo para teste

* Verificar se o banner é exibido na ordem correta na Home do app.
* Verificar se o seed está conforme solicitado na descrição.

## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
