### PR TITLE
Feature/i225 ajustes rota put user

### DIFF
--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -125,8 +125,7 @@ class UserController extends Controller
 
     public function update(
         Request $request,
-        KeycloakService $keyCloakService,
-        UserService $userService
+        KeycloakService $keyCloakService
     ) {
         $dados = $request->all();
 
@@ -141,6 +140,8 @@ class UserController extends Controller
 
         $userKeycloak = new UserKeycloak($dados);
 
+        // Atualiza tbm para o iSUS
+        // Sinto que faltou um clean code 🚀
         $user = $keyCloakService->update($userKeycloak, $request->usuario->sub);
 
         if (empty($user->id_keycloak)) {

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -129,6 +129,7 @@ class UserController extends Controller
         UserService $userService
     ) {
         $dados = $request->all();
+
         $validacao = $this->validarRequisicaoUpdate($dados);
 
         if ($validacao->fails()) {
@@ -138,17 +139,8 @@ class UserController extends Controller
             );
         }
 
-        if ($userService->verificarCpfExisteParaOutrem($dados['cpf'], $request->usuario->sub)) {
-            return response()->json(
-                [
-                    'sucesso' => false,
-                    'mensagem' => 'CPF já cadastrado no ID Saúde',
-                ],
-                Response::HTTP_CONFLICT
-            );
-        }
-
         $userKeycloak = new UserKeycloak($dados);
+
         $user = $keyCloakService->update($userKeycloak, $request->usuario->sub);
 
         if (empty($user->id_keycloak)) {
@@ -299,7 +291,6 @@ class UserController extends Controller
                 'email' => 'required|email',
                 'nomeCompleto' => 'required',
                 'telefone' => 'required|min:9|max:11',
-                'cpf' => 'required|cpf|min:11|max:11',
                 'cidadeId' => 'required',
                 'cidade' => 'required',
                 'termos' => 'accepted',

--- a/app/Service/KeycloakService.php
+++ b/app/Service/KeycloakService.php
@@ -252,7 +252,8 @@ class KeycloakService
             $this->getIdKeycloakFromHeader($resposta)
         );
 
-        $this->enviarEmailCadastro($user);
+        // TODO: voltar ao normal aqui quando ajustar o SMPT
+        // $this->enviarEmailCadastro($user);
 
         return $user;
     }


### PR DESCRIPTION
Responsáveis:  
@ericsonmoreira 

Linked Issue:  

Close #225 

### Descrição

Recentemente tivemos mudanças nas regras de negócio do `idSause` com relação ao cadastro de novos usuários. Agora, é necessário informar o CPF no preenchimento do formulário de cadastro do `idSaúde`.

Faz-se necessário providenciar ajustar no `iSUS` também. Essa issue trata do ajuste que devemos fazer para que a rota PUT `/user` não necessite mais o campo cpf como obrigatório. Já que essa informação deve ser obtida pelo idSaude. 

### Passos a passo para teste

1. Fazer uma request para a rota PUT `/user` sem passar `cpf`.
2. Não obter um resposta de erro.

## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
