### PR TITLE
⏪ voltando para enviar email no cadastro

### DIFF
--- a/app/Service/KeycloakService.php
+++ b/app/Service/KeycloakService.php
@@ -252,8 +252,7 @@ class KeycloakService
             $this->getIdKeycloakFromHeader($resposta)
         );
 
-        // TODO: voltar ao normal aqui quando ajustar o SMPT
-        // $this->enviarEmailCadastro($user);
+        $this->enviarEmailCadastro($user);
 
         return $user;
     }


### PR DESCRIPTION
Responsáveis:  
@ericsonmoreira 

Linked Issue:  
Close #222 

### Descrição

Corrigir problema que acontecia quando se tentava enviar um email no memento da criação de um novo usuário do iSUS.

### Passos a passo para teste

1. No ambiente de homologação
2. Criar um novo usuário
3. Verificar se não aconteceram erros referentes ao envio de email (SMTP)
4. Caso o usuário que foi criado tenha um email válido, verificar se um email de boas vindas ao iSUS foi enviado

## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
